### PR TITLE
fix: the logo should be good now

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -64,7 +64,7 @@ const Header = () => {
                 {pathUrl !== "/" ? (
                   <>
                     <Image
-                      src={`/images/logo/WrLogoSmLite.svg`}
+                      src={`/images/logo/WrLogoSmLite.svg`} // this is right
                       alt="logo"
                       width={240}
                       height={30}


### PR DESCRIPTION
fix #68 
only changed the logo File name 
![logo](https://github.com/user-attachments/assets/ed3dbe6d-056d-44bf-853c-a4b6d3f4d308)

So it matches this part: src={`/images/logo/WrLogoSmLite.svg`}