### PR TITLE
Fixed admin dashboard Xp section

### DIFF
--- a/src/components/Admin/Header.tsx
+++ b/src/components/Admin/Header.tsx
@@ -2,12 +2,6 @@
 
 import { useContext, useState } from 'react'
 import SidebarContext from '@/context/SidebarContext'
-import {
-  SearchIcon,
-  OutlinePersonIcon,
-  OutlineCogIcon,
-  OutlineLogoutIcon,
-} from '@/icons'
 import { Avatar } from '@roketid/windmill-react-ui'
 import { useSession } from "next-auth/react";
 import LevelBadge from "@/components/LevelBadge"

--- a/src/components/Admin/Header.tsx
+++ b/src/components/Admin/Header.tsx
@@ -11,6 +11,7 @@ import {
 import { Avatar } from '@roketid/windmill-react-ui'
 import { useSession } from "next-auth/react";
 import LevelBadge from "@/components/LevelBadge"
+import { xpForLevel } from "@/utils/XP";
 
 
 function Header() {
@@ -71,7 +72,7 @@ function Header() {
                     <LevelBadge
                       level={session?.user?.level ?? 1}
                       xp={session?.user?.xp ?? 0}
-                      xpForNextLevel={100}
+                      xpForNextLevel={xpForLevel((session?.user?.level ?? 1) + 1)}
                     />
                   </div>
                 </a>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -279,7 +279,7 @@ const Header = () => {
                           <LevelBadge
                             level={session.user.level}
                             xp={session.user.xp}
-                            xpForNextLevel={xpForLevel(session.user.level + 1)} // ✅ Add this line
+                            xpForNextLevel={xpForLevel(session.user.level + 1)}
                           />
                         )}
                     </div>


### PR DESCRIPTION
Xp progress bar was calculating xp incorrectly and displaying previous level. So 300/200 for example. 
![Screenshot 2025-04-11 at 10 47 30 AM](https://github.com/user-attachments/assets/9e2587e1-02bb-4e3b-9cc8-895a1f0adf00)

closes #97 
